### PR TITLE
Use List instead of ArrayList as parameters where possible

### DIFF
--- a/AndroidCharts/src/main/java/im/dacer/androidcharts/BarView.java
+++ b/AndroidCharts/src/main/java/im/dacer/androidcharts/BarView.java
@@ -8,6 +8,7 @@ import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.View;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by Dacer on 11/11/13.
@@ -19,8 +20,8 @@ public class BarView extends View {
     private final int TEXT_COLOR = Color.parseColor("#9B9A9B");
     private final int BACKGROUND_COLOR = Color.parseColor("#F6F6F6");
     private final int FOREGROUND_COLOR = Color.parseColor("#FC496D");
-    private ArrayList<Float> percentList;
-    private ArrayList<Float> targetPercentList;
+    private List<Float> percentList;
+    private List<Float> targetPercentList;
     private Paint textPaint;
     private Paint bgPaint;
     private Paint fgPaint;
@@ -30,7 +31,7 @@ public class BarView extends View {
     private boolean autoSetWidth = true;
     private int topMargin;
     private int bottomTextHeight;
-    private ArrayList<String> bottomTextList = new ArrayList<String>();
+    private List<String> bottomTextList = new ArrayList<String>();
     private Runnable animator = new Runnable() {
         @Override public void run() {
             boolean needNewFrame = false;
@@ -82,9 +83,9 @@ public class BarView extends View {
     /**
      * dataList will be reset when called is method.
      *
-     * @param bottomStringList The String ArrayList in the bottom.
+     * @param bottomStringList The String List in the bottom.
      */
-    public void setBottomTextList(ArrayList<String> bottomStringList) {
+    public void setBottomTextList(List<String> bottomStringList) {
         //        this.dataList = null;
         this.bottomTextList = bottomStringList;
         Rect r = new Rect();
@@ -107,9 +108,9 @@ public class BarView extends View {
     }
 
     /**
-     * @param list The ArrayList of Integer with the range of [0-max].
+     * @param list The List of Integer with the range of [0-max].
      */
-    public void setDataList(ArrayList<Integer> list, int max) {
+    public void setDataList(List<Integer> list, int max) {
         targetPercentList = new ArrayList<Float>();
         if (max == 0) max = 1;
 

--- a/AndroidCharts/src/main/java/im/dacer/androidcharts/LineView.java
+++ b/AndroidCharts/src/main/java/im/dacer/androidcharts/LineView.java
@@ -18,6 +18,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Created by Dacer on 11/4/13.
@@ -48,11 +49,11 @@ public class LineView extends View {
     private boolean autoSetGridWidth = true;
     private int dataOfAGird = 10;
     private int bottomTextHeight = 0;
-    private ArrayList<String> bottomTextList = new ArrayList<String>();
-    private ArrayList<ArrayList<Float>> dataLists;
-    private ArrayList<Integer> xCoordinateList = new ArrayList<Integer>();
-    private ArrayList<Integer> yCoordinateList = new ArrayList<Integer>();
-    private ArrayList<ArrayList<Dot>> drawDotLists = new ArrayList<ArrayList<Dot>>();
+    private List<String> bottomTextList = new ArrayList<String>();
+    private List<ArrayList<Float>> dataLists;
+    private List<Integer> xCoordinateList = new ArrayList<Integer>();
+    private List<Integer> yCoordinateList = new ArrayList<Integer>();
+    private List<ArrayList<Dot>> drawDotLists = new ArrayList<ArrayList<Dot>>();
     private Paint bottomTextPaint = new Paint();
     private int bottomTextDescent;
     private Paint popupTextPaint = new Paint();
@@ -128,9 +129,9 @@ public class LineView extends View {
     /**
      * dataList will be reset when called is method.
      *
-     * @param bottomTextList The String ArrayList in the bottom.
+     * @param bottomTextList The String List in the bottom.
      */
-    public void setBottomTextList(ArrayList<String> bottomTextList) {
+    public void setBottomTextList(List<String> bottomTextList) {
         this.bottomTextList = bottomTextList;
 
         Rect r = new Rect();
@@ -165,14 +166,14 @@ public class LineView extends View {
     }
 
     /**
-     * @param dataLists The Float ArrayLists for showing,
+     * @param dataLists The Float Lists for showing,
      * dataList.size() must be smaller than bottomTextList.size()
      */
-    public void setFloatDataList(ArrayList<ArrayList<Float>> dataLists) {
+    public void setFloatDataList(List<ArrayList<Float>> dataLists) {
         setFloatDataList(dataLists, true);
     }
 
-    public void setDataList(ArrayList<ArrayList<Integer>> dataLists) {
+    public void setDataList(List<ArrayList<Integer>> dataLists) {
         ArrayList<ArrayList<Float>> newList = new ArrayList<>();
         for (ArrayList<Integer> list : dataLists) {
             ArrayList<Float> tempList = new ArrayList<>();
@@ -184,7 +185,7 @@ public class LineView extends View {
         setFloatDataList(newList, false);
     }
 
-    public void setFloatDataList(ArrayList<ArrayList<Float>> dataLists,
+    public void setFloatDataList(List<ArrayList<Float>> dataLists,
             boolean showFloatNumInPopup) {
         selectedDot = null;
         this.showFloatNumInPopup = showFloatNumInPopup;

--- a/AndroidCharts/src/main/java/im/dacer/androidcharts/PieView.java
+++ b/AndroidCharts/src/main/java/im/dacer/androidcharts/PieView.java
@@ -10,6 +10,7 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by Dacer on 9/26/14.
@@ -85,7 +86,7 @@ public class PieView extends View {
         onPieClickListener = listener;
     }
 
-    public void setDate(ArrayList<PieHelper> helperList) {
+    public void setDate(List<PieHelper> helperList) {
         initPies(helperList);
         pieHelperList.clear();
         removeSelectedPie();
@@ -110,7 +111,7 @@ public class PieView extends View {
     /**
      * Set startDegree and endDegree for each PieHelper
      */
-    private void initPies(ArrayList<PieHelper> helperList) {
+    private void initPies(List<PieHelper> helperList) {
         float totalAngel = 270;
         for (PieHelper pie : helperList) {
             pie.setDegree(totalAngel, totalAngel + pie.getSweep());


### PR DESCRIPTION
Since the library doesn't really care whether the passed data is inside an `ArrayList` or a `LinkedList` or any other implementation of `List`, it should use `ArrayList`'s superclass `List` as parameters instead of forcing users to make use of this one specific implementation.